### PR TITLE
allow dashes within yaml front matter

### DIFF
--- a/lib/js-yaml-front.js
+++ b/lib/js-yaml-front.js
@@ -4,13 +4,13 @@ var jsYaml = require('js-yaml')
 
 jsYaml.parse = function (text, name) {
   name = name || '__content';
-  var re = /^(-{3}(?:\n|\r)([\w\W]+?)-{3})?([\w\W]*)*/
+  var re = /^(-{3}(?:\n|\r)([\w\W]+?)(?:\n|\r)-{3})?([\w\W]*)*/
     , results = re.exec(text)
     , conf = {}
     , yamlOrJson;
 
   if((yamlOrJson = results[2])) {
-    if(yamlOrJson.charAt(0) === '{') { 
+    if(yamlOrJson.charAt(0) === '{') {
       conf = JSON.parse(yamlOrJson);
     } else {
       conf = jsYaml.load(yamlOrJson);


### PR DESCRIPTION
This module doesn't work with the following front matter. The first 3 dashes in the markdown table header get used as the end of the front matter. This pull request fixes that by requiring a preceding newline character prior to the dashes that represent the end of the front matter.

```

---
designCommentary: |
    | Viewport Width | 0px | 321px | 600px | 800px | 1000px |
    | :------------: | :-: | :---: | :---: | :---: | :----: |
    | .col-2 | 1 column | → | 2 columns | → | → |
    | .col-3 | 1 column | → | → | 3 columns | → |
    | .col-4 | 1 column | 2 columns | → | 4 columns | → |
    | .col-6 | 1 column | 2 column | 3 columns | → | 6 columns |

    Gutters/Margins on the outer edges of the site container are subject to
    change, but the site container currently occupies:

    - 90% of the viewport width at 799px and below
    - 95% of the viewport width at 800px and above

---
```
