### PR TITLE
PR to fix #2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "should": "0.6.3"
   },
   "bin": {
-    "yaml-front-matter": "bin/js-yaml-front.js",
-    "js-yaml": "node_modules/js-yaml/bin/js-yaml.js"
+    "yaml-front-matter": "bin/js-yaml-front.js"
   },
   "scripts": {
     "test": "mocha -u bdd --reporter spec",


### PR DESCRIPTION
This is already declared as a bin in js-yaml's package file, npm@3 kills the assumption that this file will be present in this location when installing yaml-front-matter and this therefore stops the project from being built if js-yaml has already been installed.